### PR TITLE
Add low-battery support for it600MINITRV

### DIFF
--- a/custom_components/salus/const.py
+++ b/custom_components/salus/const.py
@@ -150,6 +150,7 @@ ENERGY_METER_VOLTAGE_MODELS: frozenset[str] = frozenset(
 TRV_VOLTAGE_MODELS: frozenset[str] = frozenset(
     {
         "TRV3RF",
+        "it600MINITRV",
     }
 )
 

--- a/custom_components/salus/gateway.py
+++ b/custom_components/salus/gateway.py
@@ -109,6 +109,7 @@ class IT600Gateway:
 
         self._sensor_devices: dict[str, SensorDevice] = {}
         self._battery_sensor_devices: dict[str, SensorDevice] = {}
+        self._binsensor_battery_devices: dict[str, SensorDevice] = {}
         self._humidity_sensor_devices: dict[str, SensorDevice] = {}
         self._energy_sensor_devices: dict[str, SensorDevice] = {}
         self._sensor_update_callbacks: list[Callable[..., Awaitable[None]]] = []
@@ -605,9 +606,11 @@ class IT600Gateway:
         self, devices: list[Any], send_callback: bool = False
     ) -> None:
         local: dict[str, BinarySensorDevice] = {}
+        trv_batt_local: dict[str, SensorDevice] = {}
 
         if not devices:
             self._binary_sensor_devices = local
+            self._binsensor_battery_devices = trv_batt_local
             return
 
         status = await self._make_encrypted_request(
@@ -696,6 +699,53 @@ class IT600Gateway:
                         entity_category="diagnostic",
                     )
 
+                # TRV low battery from sIT600I.TRVError22
+                # it600MINITRV devices don't have sPowerS or sIASZS,
+                # but report low battery via TRVError22 in sIT600I.
+                if model == "it600MINITRV":
+                    trv_low_batt = ds.get("sIT600I", {}).get("TRVError22")
+                    if trv_low_batt is not None:
+                        lb_uid = f"{unique_id}_low_battery"
+                        if lb_uid not in local:
+                            local[lb_uid] = BinarySensorDevice(
+                                available=device.available,
+                                name=f"{device.name} Low battery",
+                                unique_id=lb_uid,
+                                is_on=trv_low_batt == 1,
+                                device_class="battery",
+                                data=ds["data"],
+                                manufacturer=device.manufacturer,
+                                model=device.model,
+                                sw_version=device.sw_version,
+                                parent_unique_id=unique_id,
+                                entity_category="diagnostic",
+                            )
+
+                # Voltage-based battery sensor for models with sPowerS
+                # that are only in binary_sensor refresh (not climate).
+                power_s = ds.get("sPowerS")
+                if power_s is not None and model is not None:
+                    raw_voltage_x10 = power_s.get("BatteryVoltage_x10")
+                    if raw_voltage_x10 is not None:
+                        voltage = raw_voltage_x10 / 10.0
+                        pct = self._voltage_to_battery_pct(voltage, model)
+                        if pct is not None:
+                            battery_uid = f"{unique_id}_battery"
+                            trv_batt_local[battery_uid] = SensorDevice(
+                                available=device.available,
+                                name=f"{device.name} Battery",
+                                unique_id=battery_uid,
+                                state=pct,
+                                unit_of_measurement="%",
+                                device_class="battery",
+                                data=ds["data"],
+                                manufacturer=device.manufacturer,
+                                model=device.model,
+                                sw_version=device.sw_version,
+                                parent_unique_id=unique_id,
+                                entity_category="diagnostic",
+                            )
+
                 if send_callback:
                     self._binary_sensor_devices[device.unique_id] = device
                     await self._send_binary_sensor_update_callback(device.unique_id)
@@ -703,6 +753,7 @@ class IT600Gateway:
                 _LOGGER.exception("Failed to poll binary sensor %s", unique_id)
 
         self._binary_sensor_devices = local
+        self._binsensor_battery_devices = trv_batt_local
 
     # ---- climate ----
 
@@ -1227,6 +1278,7 @@ class IT600Gateway:
         return {
             **self._sensor_devices,
             **self._battery_sensor_devices,
+            **self._binsensor_battery_devices,
             **self._humidity_sensor_devices,
             **self._energy_sensor_devices,
         }
@@ -1235,6 +1287,7 @@ class IT600Gateway:
         return (
             self._sensor_devices.get(device_id)
             or self._battery_sensor_devices.get(device_id)
+            or self._binsensor_battery_devices.get(device_id)
             or self._humidity_sensor_devices.get(device_id)
             or self._energy_sensor_devices.get(device_id)
         )


### PR DESCRIPTION
## Summary

The `it600MINITRV` (older TRV model) lacks `sPowerS`, `sTherS`, and `sComm` clusters, so it cannot use the voltage-based battery reporting added for TRV3RF. However, it exposes `TRVError22` in the `sIT600I` cluster, which signals a low-battery condition.

This PR adds:
- **Low battery binary_sensor** from `sIT600I.TRVError22` for `it600MINITRV` devices — creates `binary_sensor.<name>_low_battery` (on = low battery)
- **`it600MINITRV` to `TRV_VOLTAGE_MODELS`** so that if a future firmware update exposes `sPowerS`, voltage-based battery % will work automatically
- **Voltage-based battery sensor reading** (`sPowerS.BatteryVoltage_x10`) in the binary_sensor refresh for any model that has `sPowerS` but is only handled by the binary_sensor refresh (not climate)
- **`_binsensor_battery_devices` dict** to properly expose these sensors through `get_sensor_devices()` / `get_sensor_device()` without being overwritten by the climate refresh cycle

## Testing

Tested on a real setup with 10x it600MINITRV (firmware `00920041`, HW version `64`) connected via UGE600 gateway:
- Confirmed via debug logs that `it600MINITRV` only exposes `sIT600I` (no `sPowerS`/`sTherS`/`sComm`)
- `binary_sensor.trv10_*_low_battery` entities are created and report `off` (battery OK) or `unavailable` (device offline)
- `TRVError22 == 0` correctly maps to `is_on=False`
- No regressions observed on SQ610RF thermostats or other device types

## Raw device data (it600MINITRV)

```json
{
  "sBasicS": {"ModelIdentifier": "it600MINITRV", "HardwareVersion": "64"},
  "sIT600I": {
    "RelayStatus": 0, "Mode": 4,
    "TRVError22": 0, "TRVError23": 0,
    "TRVError01": 0, "TRVError30": 0, "TRVError31": 0,
    "PairedThermostatShortID": 29724,
    "CommandResponse_d": "..."
  }
}
```

No `sPowerS`, `sTherS`, or `sComm` clusters available — hence the TRVError22 fallback approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)